### PR TITLE
The German payment provider Computop (https://de.computop.com/) uses …

### DIFF
--- a/chrome/content/handler/frame.js
+++ b/chrome/content/handler/frame.js
@@ -105,7 +105,7 @@ ffpwwe.frameHandler = function (page, document) {
                 let bank = /iban|(konto|account)(nr|nummer|number|bank)|blz|bankleitzahl|sortcode/;
                 // Following Regular Expression are mainly from https://code.google.com/p/chromium/codesearch#chromium/src/out/Debug/gen/autofill_regex_constants.cc
                 // License: https://code.google.com/p/chromium/codesearch#chromium/src/LICENSE
-                let cc = /pay|ccard|(card|cc).?holder|name.*\\bon\\b.*card|(card|cc).?name|cc.?full.?name|owner|karteninhaber|(card|cc|acct).?(number|#|no|num|nummer)|verification|card identification|security code|card code|cvn|cvv|cvc|csc|(card|cc|payment).?type|payment.?method|expir|exp.*mo|exp.*date|ccmonth|cardmonth|gueltig|g\xc3\xbcltig|monat|exp|^\/|year|ablaufdatum|gueltig|g\xc3\xbcltig|jahr|exp.*date.*[^y]yy([^y]|$)|expir|exp.*date/;
+                let cc = /pay|ccard|(card|cc).?holder|name.*\\bon\\b.*card|(card|cc).?name|cc.?full.?name|owner|karteninhaber|(card|cc|acct|kk).?(number|#|n[or]|num|nummer)|verification|card identification|security code|card code|cvn|cvv|cvc|csc|(card|cc|payment).?type|payment.?method|expir|exp.*mo|exp.*date|ccmonth|cardmonth|gueltig|g\xc3\xbcltig|monat|exp|^\/|year|ablaufdatum|gueltig|g\xc3\xbcltig|jahr|exp.*date.*[^y]yy([^y]|$)|expir|exp.*date/;
                 return attr.toLowerCase().match(cc) || attr.toLowerCase().match(code) || attr.toLowerCase().match(bank);
             };
         }


### PR DESCRIPTION
…"KKNr" for the credit card number input field on their hosted payment pages (https://www.computop-paygate.com/). It was not recognized as a payment field. See https://regex101.com/r/qN8aT3/1 for demo.